### PR TITLE
[METADATA UPDATE][Merge by 2024-02-07] Retiring the ms.prod and ms.technology metadata attributes from the Learn platform (values moving to ms.service)

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -43,13 +43,13 @@
     {
       "path_to_root": "_themes",
       "url": "https://github.com/Microsoft/templates.docs.msft",
-      "branch": "master",
+      "branch": "main",
       "branch_mapping": {}
     },
     {
       "path_to_root": "_themes.pdf",
       "url": "https://github.com/Microsoft/templates.docs.msft.pdf",
-      "branch": "master",
+      "branch": "main",
       "branch_mapping": {}
     }
   ],

--- a/developer/dev-guide/browser-features.md
+++ b/developer/dev-guide/browser-features.md
@@ -5,7 +5,7 @@ title: Browser - Dev guide
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/dev-guide/browser-features/autoplay-policies.md
+++ b/developer/dev-guide/browser-features/autoplay-policies.md
@@ -4,7 +4,7 @@ title: Autoplay policies - Dev guide
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, media, video, audio, autoplay
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/dev-guide/browser-features/flash.md
+++ b/developer/dev-guide/browser-features/flash.md
@@ -4,7 +4,7 @@ title: Flash - Dev guide
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, flash
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/dev-guide/browser-features/reading-view.md
+++ b/developer/dev-guide/browser-features/reading-view.md
@@ -5,7 +5,7 @@ title: Reading view - Dev guide
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/dev-guide/browser-features/search-provider-discovery.md
+++ b/developer/dev-guide/browser-features/search-provider-discovery.md
@@ -5,7 +5,7 @@ title: Search provider discovery - Dev guide
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/dev-guide/index.md
+++ b/developer/dev-guide/index.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: edgehtml
 keywords: edge, web development, html, css, javascript, developer, devtools
 ms.custom: RS5

--- a/developer/dev-guide/whats-new.md
+++ b/developer/dev-guide/whats-new.md
@@ -4,7 +4,7 @@ title: What's new in EdgeHTML for developers - Dev guide
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer, what's new in edge, new APIs in edge, edgehtml, edgehtml preview builds
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/dev-guide/whats-new/edgeHTML-12.md
+++ b/developer/dev-guide/whats-new/edgeHTML-12.md
@@ -4,7 +4,7 @@ title: New features and APIs in EdgeHTML 12
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/dev-guide/whats-new/edgeHTML-13.md
+++ b/developer/dev-guide/whats-new/edgeHTML-13.md
@@ -4,7 +4,7 @@ title: New features and APIs in EdgeHTML 13
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/dev-guide/whats-new/edgeHTML-14.md
+++ b/developer/dev-guide/whats-new/edgeHTML-14.md
@@ -4,7 +4,7 @@ title: New features and APIs in EdgeHTML 14
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/dev-guide/whats-new/edgeHTML-15.md
+++ b/developer/dev-guide/whats-new/edgeHTML-15.md
@@ -4,7 +4,7 @@ title: New features and APIs in EdgeHTML 15
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.custom: seodec18
 ms.date: 12/02/2020

--- a/developer/dev-guide/whats-new/edgeHTML-16.md
+++ b/developer/dev-guide/whats-new/edgeHTML-16.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.assetid: 476c4b7a-be24-434b-a051-83f19d741aaf
 keywords: edge, web development, html, css, javascript, developer
 ---

--- a/developer/dev-guide/whats-new/edgeHTML-17.md
+++ b/developer/dev-guide/whats-new/edgeHTML-17.md
@@ -4,7 +4,7 @@ description: This guide provides an overview of the developer features and stand
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/dev-guide/whats-new/javascript-version-information.md
+++ b/developer/dev-guide/whats-new/javascript-version-information.md
@@ -1,7 +1,7 @@
 ---
 title: JavaScript version information
 description: Compare JavaScript support across Microsoft Edge, Microsoft Store apps, and Internet Explorer
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: language-reference
 author: MSEdgeTeam
 ms.author: msedgedevrel

--- a/developer/dev-guide/windows-integration.md
+++ b/developer/dev-guide/windows-integration.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
 ms.technology: windows-integration
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/dev-guide/windows-integration/Payment-Request-API.md
+++ b/developer/dev-guide/windows-integration/Payment-Request-API.md
@@ -4,7 +4,7 @@ title: Payment Request API - Dev guide
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: windows-integration
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020

--- a/developer/dev-guide/windows-integration/web-Notifications-API.md
+++ b/developer/dev-guide/windows-integration/web-Notifications-API.md
@@ -5,7 +5,7 @@ title: Web Notifications API - Dev guide
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/dev-guide/windows-integration/web-authentication.md
+++ b/developer/dev-guide/windows-integration/web-authentication.md
@@ -5,7 +5,7 @@ title: Web Authentication - Dev guide
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: windows-integration
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020

--- a/developer/devtools-guide/console.md
+++ b/developer/devtools-guide/console.md
@@ -4,7 +4,7 @@ title: DevTools - Console
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, console
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/console/command-line.md
+++ b/developer/devtools-guide/console/command-line.md
@@ -4,7 +4,7 @@ title: DevTools - Console - Command Line
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, console command line
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/console/console-api.md
+++ b/developer/devtools-guide/console/console-api.md
@@ -4,7 +4,7 @@ title: DevTools - Console - Console API
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, console api
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/console/error-and-status-codes.md
+++ b/developer/devtools-guide/console/error-and-status-codes.md
@@ -5,7 +5,7 @@ title: DevTools - Console error and status codes
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, console codes
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/debugger.md
+++ b/developer/devtools-guide/debugger.md
@@ -4,7 +4,7 @@ title: Debugger - DevTools (EdgeHTML)
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, debugger, debugging, breakpoints, watches, service workers, cache api, web storage, cookies
 ms.custom: seodec18
 ms.date: 12/02/2020

--- a/developer/devtools-guide/elements.md
+++ b/developer/devtools-guide/elements.md
@@ -4,7 +4,7 @@ title: DevTools - Elements
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, elements, html, css, dom breakpoints, events, accessibility
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/elements/accessibility.md
+++ b/developer/devtools-guide/elements/accessibility.md
@@ -4,7 +4,7 @@ title: Accessibility - DevTools (EdgeHTML)
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, elements, accessibility
 ms.custom: seodec18
 ms.date: 12/02/2020

--- a/developer/devtools-guide/elements/changes.md
+++ b/developer/devtools-guide/elements/changes.md
@@ -4,7 +4,7 @@ title: DevTools - Elements - Changes
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, elements, css changes, css diff
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/elements/computed.md
+++ b/developer/devtools-guide/elements/computed.md
@@ -4,7 +4,7 @@ title: DevTools - Elements - Computed
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, elements, css, computed value, box model
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/elements/dom-breakpoints.md
+++ b/developer/devtools-guide/elements/dom-breakpoints.md
@@ -4,7 +4,7 @@ title: DevTools - Elements - DOM breakpoints
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, elements, dom breakpoints, dom mutation
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/elements/events.md
+++ b/developer/devtools-guide/elements/events.md
@@ -4,7 +4,7 @@ title: DevTools - Elements - Events
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, elements, event listeners, event handlers
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/elements/fonts.md
+++ b/developer/devtools-guide/elements/fonts.md
@@ -4,7 +4,7 @@ title: DevTools - Elements - Fonts
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, elements, fonts, @font-face
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/elements/styles.md
+++ b/developer/devtools-guide/elements/styles.md
@@ -4,7 +4,7 @@ title: DevTools - Elements - Styles
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, elements, styles, pseudo state, pseudo classe, pseudo element
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/emulation.md
+++ b/developer/devtools-guide/emulation.md
@@ -4,7 +4,7 @@ title: DevTools - Emulation
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, device emulation, responsive design, geolocation, resolution
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/index.md
+++ b/developer/devtools-guide/index.md
@@ -4,7 +4,7 @@ title: Microsoft Edge (EdgeHTML) Developer Tools
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: devtools
 keywords: microsoft edge, web development, f12 tools, devtools
 ms.date: 12/02/2020

--- a/developer/devtools-guide/memory.md
+++ b/developer/devtools-guide/memory.md
@@ -4,7 +4,7 @@ title: DevTools - Memory
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, memory, heap, GC, garbage collection, retained size, dominators
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/network.md
+++ b/developer/devtools-guide/network.md
@@ -4,7 +4,7 @@ title: DevTools - Network
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, network, load time, http, https, browser cache, HAR
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/performance.md
+++ b/developer/devtools-guide/performance.md
@@ -4,7 +4,7 @@ title: DevTools - Performance
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, performance, profile, frame rate, fps, CPU utilization, JavaScript execution
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/service-workers.md
+++ b/developer/devtools-guide/service-workers.md
@@ -4,7 +4,7 @@ title: DevTools - Debugger - Service Workers
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, debugger, debugging, pwa, service worker, cache api
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/storage.md
+++ b/developer/devtools-guide/storage.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, web storage, local storage, session storage, indexeddb, cookies, service worker, cache
 ms.custom: seodec18
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/devtools-guide/whats-new.md
+++ b/developer/devtools-guide/whats-new.md
@@ -4,7 +4,7 @@ title: What's new in the Microsoft Edge DevTools
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, edgehtml 18
 ms.custom: RS5, seodec18
 ms.date: 12/02/2020

--- a/developer/devtools-guide/whats-new/edgehtml-16.md
+++ b/developer/devtools-guide/whats-new/edgehtml-16.md
@@ -4,7 +4,7 @@ title: DevTools in EdgeHTML 16
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, edgehtml 16
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/devtools-guide/whats-new/edgehtml-17.md
+++ b/developer/devtools-guide/whats-new/edgehtml-17.md
@@ -4,7 +4,7 @@ title: DevTools in EdgeHTML 17
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: microsoft edge, web development, f12 tools, devtools, edgehtml 17
 ms.custom: seodec18
 ms.date: 12/02/2020

--- a/developer/devtools-protocol/0.1/clients.md
+++ b/developer/devtools-protocol/0.1/clients.md
@@ -4,7 +4,7 @@ title: DevTools Protocol Version 0.1 Clients (EdgeHTML)
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/devtools-protocol/0.1/domains/debugger.md
+++ b/developer/devtools-protocol/0.1/domains/debugger.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/devtools-protocol/0.1/domains/index.md
+++ b/developer/devtools-protocol/0.1/domains/index.md
@@ -4,7 +4,7 @@ title: DevTools Protocol Domains - DevTools Protocol Version 0.1 (EdgeHTML)
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/devtools-protocol/0.1/domains/page.md
+++ b/developer/devtools-protocol/0.1/domains/page.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/devtools-protocol/0.1/domains/runtime.md
+++ b/developer/devtools-protocol/0.1/domains/runtime.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/devtools-protocol/0.1/domains/schema.md
+++ b/developer/devtools-protocol/0.1/domains/schema.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/devtools-protocol/0.1/http.md
+++ b/developer/devtools-protocol/0.1/http.md
@@ -4,7 +4,7 @@ title: DevTools Protocol Version 0.1 HTTP Endpoints (EdgeHTML)
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/devtools-protocol/0.1/index.md
+++ b/developer/devtools-protocol/0.1/index.md
@@ -4,7 +4,7 @@ title: DevTools Protocol Version 0.1 Release Notes
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/devtools-protocol/0.2/clients.md
+++ b/developer/devtools-protocol/0.2/clients.md
@@ -4,7 +4,7 @@ title: Microsoft Edge DevTools Protocol Version 0.2 Clients (EdgeHTML)
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/devtools-protocol/0.2/domains/css.md
+++ b/developer/devtools-protocol/0.2/domains/css.md
@@ -4,7 +4,7 @@ title: CSS Domain - DevTools Protocol Version 0.2
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/devtools-protocol/0.2/domains/debugger.md
+++ b/developer/devtools-protocol/0.2/domains/debugger.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/devtools-protocol/0.2/domains/dom.md
+++ b/developer/devtools-protocol/0.2/domains/dom.md
@@ -4,7 +4,7 @@ title: DOM Domain - DevTools Protocol Version 0.2
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.custom: seodec18
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/devtools-protocol/0.2/domains/domdebugger.md
+++ b/developer/devtools-protocol/0.2/domains/domdebugger.md
@@ -4,7 +4,7 @@ title: DOMDebugger Domain - DevTools Protocol Version 0.2
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/devtools-protocol/0.2/domains/index.md
+++ b/developer/devtools-protocol/0.2/domains/index.md
@@ -4,7 +4,7 @@ title: DevTools Protocol Domains - DevTools Protocol Version 0.2 (EdgeHTML)
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/devtools-protocol/0.2/domains/overlay.md
+++ b/developer/devtools-protocol/0.2/domains/overlay.md
@@ -4,7 +4,7 @@ title: Overlay Domain - DevTools Protocol Version 0.2
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/devtools-protocol/0.2/domains/page.md
+++ b/developer/devtools-protocol/0.2/domains/page.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ROBOTS: NOINDEX,NOFOLLOW
 ---
 # Page Domain - DevTools Protocol Version 0.2 (EdgeHTML)  

--- a/developer/devtools-protocol/0.2/domains/runtime.md
+++ b/developer/devtools-protocol/0.2/domains/runtime.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ROBOTS: NOINDEX,NOFOLLOW
 ---
 # Runtime Domain - DevTools Protocol Version 0.2 (EdgeHTML)  

--- a/developer/devtools-protocol/0.2/domains/schema.md
+++ b/developer/devtools-protocol/0.2/domains/schema.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ROBOTS: NOINDEX,NOFOLLOW
 ---
 # Schema Domain - DevTools Protocol Version 0.2 (EdgeHTML)  

--- a/developer/devtools-protocol/0.2/http.md
+++ b/developer/devtools-protocol/0.2/http.md
@@ -4,7 +4,7 @@ title: Microsoft Edge DevTools Protocol Version 0.2 HTTP Endpoints (EdgeHTML)
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/devtools-protocol/0.2/index.md
+++ b/developer/devtools-protocol/0.2/index.md
@@ -4,7 +4,7 @@ title: Microsoft Edge DevTools Protocol Version 0.2 Release Notes
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/devtools-protocol/index.md
+++ b/developer/devtools-protocol/index.md
@@ -4,7 +4,7 @@ title: Microsoft Edge DevTools Protocol
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.date: 03/16/2021
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/extensions/API-support.md
+++ b/developer/extensions/API-support.md
@@ -5,7 +5,7 @@ title: Extensions - API support
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/API-support/extension-API-roadmap.md
+++ b/developer/extensions/API-support/extension-API-roadmap.md
@@ -4,7 +4,7 @@ title: Extensions API roadmap
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, api, extensions, javascript, developer
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/extensions/API-support/supported-APIs.md
+++ b/developer/extensions/API-support/supported-APIs.md
@@ -4,7 +4,7 @@ title: Extensions - Supported APIs
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/API-support/supported-manifest-keys.md
+++ b/developer/extensions/API-support/supported-manifest-keys.md
@@ -4,7 +4,7 @@ title: Extensions - Supported manifest keys
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/API-support/supported-manifest-keys/json-manifest-example.md
+++ b/developer/extensions/API-support/supported-manifest-keys/json-manifest-example.md
@@ -5,7 +5,7 @@ title: Extensions - JSON manifest example
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/extensions/extensions-for-enterprise.md
+++ b/developer/extensions/extensions-for-enterprise.md
@@ -5,7 +5,7 @@ title: Extensions for enterprise
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/extensions/getting-started.md
+++ b/developer/extensions/getting-started.md
@@ -4,7 +4,7 @@ title: Extensions - Getting started
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer, extensions
 ms.date: 03/16/2021
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/guides.md
+++ b/developer/extensions/guides.md
@@ -5,7 +5,7 @@ title: Extensions - Guides
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/guides/accessibility.md
+++ b/developer/extensions/guides/accessibility.md
@@ -5,7 +5,7 @@ title: Accessibility - Extensions (EdgeHTML)
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/guides/adding-and-removing-extensions.md
+++ b/developer/extensions/guides/adding-and-removing-extensions.md
@@ -4,7 +4,7 @@ title: Adding and removing extensions
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer, extension
 ms.custom: seodec18
 ms.date: 12/15/2020

--- a/developer/extensions/guides/creating-an-extension.md
+++ b/developer/extensions/guides/creating-an-extension.md
@@ -4,7 +4,7 @@ title: Creating an extension
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/extensions/guides/debugging-extensions.md
+++ b/developer/extensions/guides/debugging-extensions.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, javascript, developer, debug, debugging
 ms.custom: seodec18
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/guides/design.md
+++ b/developer/extensions/guides/design.md
@@ -4,7 +4,7 @@ title: Extensions - Design
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, javascript, design, icons, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/guides/internationalization.md
+++ b/developer/extensions/guides/internationalization.md
@@ -4,7 +4,7 @@ title: Extensions - Internationalization
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/guides/native-messaging.md
+++ b/developer/extensions/guides/native-messaging.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer, native, messaging, uwp
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/extensions/guides/packaging.md
+++ b/developer/extensions/guides/packaging.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 10/28/2020
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.assetid: f3560505-e01f-47e5-9ad6-7a419f060fc2
 keywords: edge, web development, html, css, javascript, developer
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/guides/packaging/creating-and-testing-extension-packages.md
+++ b/developer/extensions/guides/packaging/creating-and-testing-extension-packages.md
@@ -5,7 +5,7 @@ title: Creating and testing extension packages
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer, packaging
 ms.custom: seodec18
 ms.date: 12/02/2020

--- a/developer/extensions/guides/packaging/extensions-in-the-windows-dev-center.md
+++ b/developer/extensions/guides/packaging/extensions-in-the-windows-dev-center.md
@@ -4,7 +4,7 @@ title: Extensions in Partner Center
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/extensions/guides/packaging/localizing-extension-packages.md
+++ b/developer/extensions/guides/packaging/localizing-extension-packages.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.assetid: c4043c1e-15ac-4210-8851-3804c7708f49
 keywords: edge, web development, html, css, javascript, developer
 ms.custom: seodec18

--- a/developer/extensions/guides/packaging/running-the-windows-app-certification-kit.md
+++ b/developer/extensions/guides/packaging/running-the-windows-app-certification-kit.md
@@ -4,7 +4,7 @@ title: Extensions - Running the Windows App Certification Kit
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/guides/packaging/using-ManifoldJS-to-package-extensions.md
+++ b/developer/extensions/guides/packaging/using-ManifoldJS-to-package-extensions.md
@@ -5,7 +5,7 @@ title: Using ManifoldJS to package extensions
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/extensions/guides/porting-Chrome-extensions.md
+++ b/developer/extensions/guides/porting-Chrome-extensions.md
@@ -5,7 +5,7 @@ title: Porting Chrome extensions
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.custom: seodec18
 ms.date: 11/19/2020

--- a/developer/extensions/includes/deprecation-note.md
+++ b/developer/extensions/includes/deprecation-note.md
@@ -1,7 +1,7 @@
 ---
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: include
 ms.date: 02/10/2021
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/extensions/index.md
+++ b/developer/extensions/index.md
@@ -4,7 +4,7 @@ title: Extensions
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: extensions
 keywords: edge, web development, html, css, javascript, developer, extensions
 ms.date: 11/19/2020

--- a/developer/extensions/tips-and-tricks.md
+++ b/developer/extensions/tips-and-tricks.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer, extensions
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/extensions/troubleshooting.md
+++ b/developer/extensions/troubleshooting.md
@@ -5,7 +5,7 @@ title: Extensions - Troubleshooting
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/chakra-hosting/hosting-the-javascript-runtime.md
+++ b/developer/hosting/chakra-hosting/hosting-the-javascript-runtime.md
@@ -1,7 +1,7 @@
 ---
 description: "Use the standards-based Chakra JavaScript engine to add scripting capabilities to your Windows application."
 title: "Hosting the JavaScript Runtime"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "article"
 ms.assetid: 30ec744e-57cc-4ef5-8fe1-d2c27b946548
 caps.latest.revision: 14

--- a/developer/hosting/chakra-hosting/javascript-runtime-typedefs-constants-and-enumerations.md
+++ b/developer/hosting/chakra-hosting/javascript-runtime-typedefs-constants-and-enumerations.md
@@ -1,7 +1,7 @@
 ---
 description: "JavaScript Runtime (JsRT) typedefs, constants, and enumerations support adding scripting capabilities to desktop and server-side applications running on Windows."
 title: "JavaScript Runtime Typedefs, Constants, and Enumerations"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "article"
 ms.assetid: 1aa107ed-e144-4947-b5bb-90284a537174
 caps.latest.revision: 5

--- a/developer/hosting/chakra-hosting/js-invalid-propertyid-constant.md
+++ b/developer/hosting/chakra-hosting/js-invalid-propertyid-constant.md
@@ -1,7 +1,7 @@
 ---
 description: "An invalid property identifier."
 title: "JS_INVALID_PROPERTYID Constant | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 1d2e8768-b2c9-4447-b3f2-3b2ac0abad4f
 caps.latest.revision: 11

--- a/developer/hosting/chakra-hosting/js-invalid-reference-constant.md
+++ b/developer/hosting/chakra-hosting/js-invalid-reference-constant.md
@@ -1,7 +1,7 @@
 ---
 description: "An invalid reference."
 title: "JS_INVALID_REFERENCE Constant | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JS_INVALID_REFERENCE"

--- a/developer/hosting/chakra-hosting/js-invalid-runtime-handle-constant.md
+++ b/developer/hosting/chakra-hosting/js-invalid-runtime-handle-constant.md
@@ -1,7 +1,7 @@
 ---
 description: "An invalid runtime handle."
 title: "JS_INVALID_RUNTIME_HANDLE Constant | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JS_INVALID_RUNTIME_HANDLE"

--- a/developer/hosting/chakra-hosting/js-source-context-none-constant.md
+++ b/developer/hosting/chakra-hosting/js-source-context-none-constant.md
@@ -1,7 +1,7 @@
 ---
 description: "An empty source context."
 title: "JS_SOURCE_CONTEXT_NONE Constant | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JS_SOURCE_CONTEXT_NONE"

--- a/developer/hosting/chakra-hosting/jsaddref-function.md
+++ b/developer/hosting/chakra-hosting/jsaddref-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Adds a reference to a garbage collected object."
 title: "JsAddRef Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsAddRef"

--- a/developer/hosting/chakra-hosting/jsbackgroundworkitemcallback-typedef.md
+++ b/developer/hosting/chakra-hosting/jsbackgroundworkitemcallback-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A background work item callback."
 title: "JsBackgroundWorkItemCallback Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: e6db52e1-830c-46a2-b9f9-cc2d450a1da8
 caps.latest.revision: 6

--- a/developer/hosting/chakra-hosting/jsbeforecollectcallback-typedef.md
+++ b/developer/hosting/chakra-hosting/jsbeforecollectcallback-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A callback called before collection."
 title: "JsBeforeCollectCallback Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 58bece47-4e6d-49e7-a93d-b6a8f9928b41
 caps.latest.revision: 6

--- a/developer/hosting/chakra-hosting/jsbooleantobool-function.md
+++ b/developer/hosting/chakra-hosting/jsbooleantobool-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Retrieves the `bool` value of a Boolean value."
 title: "JsBooleanToBool Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsBooleanToBool"

--- a/developer/hosting/chakra-hosting/jsbooltoboolean-function.md
+++ b/developer/hosting/chakra-hosting/jsbooltoboolean-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a Boolean value from a `bool` value."
 title: "JsBoolToBoolean Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsBoolToBoolean"

--- a/developer/hosting/chakra-hosting/jscallfunction-function.md
+++ b/developer/hosting/chakra-hosting/jscallfunction-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Invokes a function."
 title: "JsCallFunction Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCallFunction"

--- a/developer/hosting/chakra-hosting/jscollectgarbage-function.md
+++ b/developer/hosting/chakra-hosting/jscollectgarbage-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Performs a full garbage collection."
 title: "JsCollectGarbage Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCollectGarbage"

--- a/developer/hosting/chakra-hosting/jsconstructobject-function.md
+++ b/developer/hosting/chakra-hosting/jsconstructobject-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Invokes a function as a constructor."
 title: "JsConstructObject Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsConstructObject"

--- a/developer/hosting/chakra-hosting/jscontextref-typedef.md
+++ b/developer/hosting/chakra-hosting/jscontextref-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A reference to a script context."
 title: "JsContextRef Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 8586bfcc-bb24-430d-a6f2-1a3b3e34ec2e
 caps.latest.revision: 6

--- a/developer/hosting/chakra-hosting/jsconvertvaluetoboolean-function.md
+++ b/developer/hosting/chakra-hosting/jsconvertvaluetoboolean-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Converts the value to Boolean using standard JavaScript semantics."
 title: "JsConvertValueToBoolean Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsConvertValueToBoolean"

--- a/developer/hosting/chakra-hosting/jsconvertvaluetonumber-function.md
+++ b/developer/hosting/chakra-hosting/jsconvertvaluetonumber-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Converts the value to number using standard JavaScript semantics."
 title: "JsConvertValueToNumber Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsConvertValueToNumber"

--- a/developer/hosting/chakra-hosting/jsconvertvaluetoobject-function.md
+++ b/developer/hosting/chakra-hosting/jsconvertvaluetoobject-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Converts the value to object using standard JavaScript semantics."
 title: "JsConvertValueToObject Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsConvertValueToObject"

--- a/developer/hosting/chakra-hosting/jsconvertvaluetostring-function.md
+++ b/developer/hosting/chakra-hosting/jsconvertvaluetostring-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Converts the value to string using standard JavaScript semantics."
 title: "JsConvertValueToString Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsConvertValueToString"

--- a/developer/hosting/chakra-hosting/jscreatearray-function.md
+++ b/developer/hosting/chakra-hosting/jscreatearray-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a Javascript array object."
 title: "JsCreateArray Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateArray"

--- a/developer/hosting/chakra-hosting/jscreatearraybuffer-function.md
+++ b/developer/hosting/chakra-hosting/jscreatearraybuffer-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a JavaScript `ArrayBuffer` object."
 title: "JsCreateArrayBuffer Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: c9e74184-7dd9-41a7-a1fe-9575e1701392
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jscreatecontext-function.md
+++ b/developer/hosting/chakra-hosting/jscreatecontext-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a script context for running scripts."
 title: "JsCreateContext Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateContext"

--- a/developer/hosting/chakra-hosting/jscreatedataview-function.md
+++ b/developer/hosting/chakra-hosting/jscreatedataview-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a Javascript `DataView` object."
 title: "JsCreateDataView Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 161e59eb-d429-46f7-9a38-bbf2149ccf44
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jscreateerror-function.md
+++ b/developer/hosting/chakra-hosting/jscreateerror-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a new JavaScript error object."
 title: "JsCreateError Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateError"

--- a/developer/hosting/chakra-hosting/jscreateexternalarraybuffer-function.md
+++ b/developer/hosting/chakra-hosting/jscreateexternalarraybuffer-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a Javascript `ArrayBuffer` object to access external memory."
 title: "JsCreateExternalArrayBuffer Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "article"
 ms.assetid: 4a02aaec-0f67-4bf9-b37c-71cdb1410ca4
 caps.latest.revision: 3

--- a/developer/hosting/chakra-hosting/jscreateexternalobject-function.md
+++ b/developer/hosting/chakra-hosting/jscreateexternalobject-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a new object that stores some external data."
 title: "JsCreateExternalObject Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateExternalObject"

--- a/developer/hosting/chakra-hosting/jscreatefunction-function.md
+++ b/developer/hosting/chakra-hosting/jscreatefunction-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a new JavaScript function."
 title: "JsCreateFunction Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateFunction"

--- a/developer/hosting/chakra-hosting/jscreatenamedfunction-function.md
+++ b/developer/hosting/chakra-hosting/jscreatenamedfunction-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a new JavaScript function with name."
 title: "JsCreateNamedFunction Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 72f40d06-ab82-4fed-a632-68af6b4126c2
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jscreateobject-function.md
+++ b/developer/hosting/chakra-hosting/jscreateobject-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a new object."
 title: "JsCreateObject Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateObject"

--- a/developer/hosting/chakra-hosting/jscreaterangeerror-function.md
+++ b/developer/hosting/chakra-hosting/jscreaterangeerror-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a new JavaScript RangeError error object."
 title: "JsCreateRangeError Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateRangeError"

--- a/developer/hosting/chakra-hosting/jscreatereferenceerror-function.md
+++ b/developer/hosting/chakra-hosting/jscreatereferenceerror-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a new JavaScript ReferenceError error object."
 title: "JsCreateReferenceError Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateReferenceError"

--- a/developer/hosting/chakra-hosting/jscreateruntime-function.md
+++ b/developer/hosting/chakra-hosting/jscreateruntime-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a new runtime."
 title: "JsCreateRuntime Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateRuntime"

--- a/developer/hosting/chakra-hosting/jscreatesymbol-function.md
+++ b/developer/hosting/chakra-hosting/jscreatesymbol-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a JavaScript symbol."
 title: "JsCreateSymbol Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 2fccc5d9-f857-46cd-9aeb-f0a2e7cdee6b
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jscreatesyntaxerror-function.md
+++ b/developer/hosting/chakra-hosting/jscreatesyntaxerror-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a new JavaScript SyntaxError error object."
 title: "JsCreateSyntaxError Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateSyntaxError"

--- a/developer/hosting/chakra-hosting/jscreatetypedarray-function.md
+++ b/developer/hosting/chakra-hosting/jscreatetypedarray-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a JavaScript typed array object."
 title: "JsCreateTypedArray Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 937a2a91-6f5f-4aaa-a018-d3089702bf36
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jscreatetypeerror-function.md
+++ b/developer/hosting/chakra-hosting/jscreatetypeerror-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a new JavaScript TypeError error object."
 title: "JsCreateTypeError Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateTypeError"

--- a/developer/hosting/chakra-hosting/jscreateurierror-function.md
+++ b/developer/hosting/chakra-hosting/jscreateurierror-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a new JavaScript URIError error object."
 title: "JsCreateURIError Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsCreateURIError"

--- a/developer/hosting/chakra-hosting/jsdefineproperty-function.md
+++ b/developer/hosting/chakra-hosting/jsdefineproperty-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Defines a new object's own property from a property descriptor."
 title: "JsDefineProperty Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsDefineProperty"

--- a/developer/hosting/chakra-hosting/jsdeleteindexedproperty-function.md
+++ b/developer/hosting/chakra-hosting/jsdeleteindexedproperty-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Delete the value at the specified index of an object."
 title: "JsDeleteIndexedProperty Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsDeleteIndexedProperty"

--- a/developer/hosting/chakra-hosting/jsdeleteproperty-function.md
+++ b/developer/hosting/chakra-hosting/jsdeleteproperty-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Deletes an object's property."
 title: "JsDeleteProperty Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsDeleteProperty"

--- a/developer/hosting/chakra-hosting/jsdisableruntimeexecution-function.md
+++ b/developer/hosting/chakra-hosting/jsdisableruntimeexecution-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Suspends script execution and terminates any running scripts in a runtime."
 title: "JsDisableRuntimeExecution Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsDisableRuntimeExecution"

--- a/developer/hosting/chakra-hosting/jsdisposeruntime-function.md
+++ b/developer/hosting/chakra-hosting/jsdisposeruntime-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Disposes a runtime."
 title: "JsDisposeRuntime Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsDisposeRuntime"

--- a/developer/hosting/chakra-hosting/jsdoubletonumber-function.md
+++ b/developer/hosting/chakra-hosting/jsdoubletonumber-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a number value from a double value."
 title: "JsDoubleToNumber Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsDoubleToNumber"

--- a/developer/hosting/chakra-hosting/jsenableruntimeexecution-function.md
+++ b/developer/hosting/chakra-hosting/jsenableruntimeexecution-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Enables script execution in a runtime. "
 title: "JsEnableRuntimeExecution Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsEnableRuntimeExecution"

--- a/developer/hosting/chakra-hosting/jsenumerateheap-function.md
+++ b/developer/hosting/chakra-hosting/jsenumerateheap-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Enumerates the heap of the current context."
 title: "JsEnumerateHeap Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsEnumerateHeap"

--- a/developer/hosting/chakra-hosting/jsequals-function.md
+++ b/developer/hosting/chakra-hosting/jsequals-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Compare two JavaScript values for equality."
 title: "JsEquals Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsEquals"

--- a/developer/hosting/chakra-hosting/jserrorcode-enumeration.md
+++ b/developer/hosting/chakra-hosting/jserrorcode-enumeration.md
@@ -1,7 +1,7 @@
 ---
 description: "An error code returned from a Chakra hosting API."
 title: "JsErrorCode Enumeration | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsErrorCode"

--- a/developer/hosting/chakra-hosting/jsfinalizecallback-typedef.md
+++ b/developer/hosting/chakra-hosting/jsfinalizecallback-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A finalizer callback."
 title: "JsFinalizeCallback Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: aa7a0269-b9d4-4717-97ac-8da7eb6ced15
 caps.latest.revision: 6

--- a/developer/hosting/chakra-hosting/jsgetandclearexception-function.md
+++ b/developer/hosting/chakra-hosting/jsgetandclearexception-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Returns the exception that caused the runtime of the current context to be in the exception state and resets the exception state for that runtime."
 title: "JsGetAndClearException Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetAndClearException"

--- a/developer/hosting/chakra-hosting/jsgetarraybufferstorage-function.md
+++ b/developer/hosting/chakra-hosting/jsgetarraybufferstorage-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Obtains the underlying memory storage used by an ArrayBuffer."
 title: "JsGetArrayBufferStorage Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 712ae298-36a9-47ef-b089-e51835c056bc
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsgetcontextdata-function.md
+++ b/developer/hosting/chakra-hosting/jsgetcontextdata-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the internal data set on JsrtContext."
 title: "JsGetContextData Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "article"
 ms.assetid: f5d7e446-267a-4a80-a427-6e1b95a3391b
 caps.latest.revision: 4

--- a/developer/hosting/chakra-hosting/jsgetcontextofobject-function.md
+++ b/developer/hosting/chakra-hosting/jsgetcontextofobject-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the script context that the object belongs to."
 title: "JsGetContextOfObject Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "article"
 ms.assetid: cea6cdcd-790f-455c-af04-026af8ae2eb7
 caps.latest.revision: 3

--- a/developer/hosting/chakra-hosting/jsgetcurrentcontext-function.md
+++ b/developer/hosting/chakra-hosting/jsgetcurrentcontext-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the current script context on the thread."
 title: "JsGetCurrentContext Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetCurrentContext"

--- a/developer/hosting/chakra-hosting/jsgetdataviewstorage-function.md
+++ b/developer/hosting/chakra-hosting/jsgetdataviewstorage-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Obtains the underlying memory storage used by a DataView."
 title: "JsGetDataViewStorage Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 7c2180e0-51d5-4cc8-ad21-8bf29ff7c583
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsgetextensionallowed-function.md
+++ b/developer/hosting/chakra-hosting/jsgetextensionallowed-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Returns a value that indicates whether an object is extensible or not."
 title: "JsGetExtensionAllowed Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetExtensionAllowed"

--- a/developer/hosting/chakra-hosting/jsgetexternaldata-function.md
+++ b/developer/hosting/chakra-hosting/jsgetexternaldata-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Retrieves the data from an external object."
 title: "JsGetExternalData Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetExternalData"

--- a/developer/hosting/chakra-hosting/jsgetfalsevalue-function.md
+++ b/developer/hosting/chakra-hosting/jsgetfalsevalue-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the value of `false` in the current script context."
 title: "JsGetFalseValue Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetFalseValue"

--- a/developer/hosting/chakra-hosting/jsgetglobalobject-function.md
+++ b/developer/hosting/chakra-hosting/jsgetglobalobject-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the global object in the current script context."
 title: "JsGetGlobalObject Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetGlobalObject"

--- a/developer/hosting/chakra-hosting/jsgetindexedpropertiesexternaldata-function.md
+++ b/developer/hosting/chakra-hosting/jsgetindexedpropertiesexternaldata-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Retrieves an object's indexed properties external data information."
 title: "JsGetIndexedPropertiesExternalData Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 2c313163-3462-42fd-8dee-3dfb3ac7f43f
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsgetindexedproperty-function.md
+++ b/developer/hosting/chakra-hosting/jsgetindexedproperty-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Retrieve the value at the specified index of an object."
 title: "JsGetIndexedProperty Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetIndexedProperty"

--- a/developer/hosting/chakra-hosting/jsgetnullvalue-function.md
+++ b/developer/hosting/chakra-hosting/jsgetnullvalue-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the value of `null` in the current script context."
 title: "JsGetNullValue Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetNullValue"

--- a/developer/hosting/chakra-hosting/jsgetownpropertydescriptor-function.md
+++ b/developer/hosting/chakra-hosting/jsgetownpropertydescriptor-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets a property descriptor for an object's own property."
 title: "JsGetOwnPropertyDescriptor Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetOwnPropertyDescriptor"

--- a/developer/hosting/chakra-hosting/jsgetownpropertynames-function.md
+++ b/developer/hosting/chakra-hosting/jsgetownpropertynames-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the list of all properties on the object."
 title: "JsGetOwnPropertyNames Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetOwnPropertyNames"

--- a/developer/hosting/chakra-hosting/jsgetownpropertysymbols-function.md
+++ b/developer/hosting/chakra-hosting/jsgetownpropertysymbols-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the list of all symbol properties on the object."
 title: "JsGetOwnPropertySymbols Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 57c431e3-de0b-4ed0-b750-87a86448daff
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsgetproperty-function.md
+++ b/developer/hosting/chakra-hosting/jsgetproperty-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets an object's property."
 title: "JsGetProperty Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetProperty"

--- a/developer/hosting/chakra-hosting/jsgetpropertyidfromname-function.md
+++ b/developer/hosting/chakra-hosting/jsgetpropertyidfromname-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the property ID associated with the name."
 title: "JsGetPropertyIdFromName Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetPropertyIdFromName"

--- a/developer/hosting/chakra-hosting/jsgetpropertyidfromsymbol-function.md
+++ b/developer/hosting/chakra-hosting/jsgetpropertyidfromsymbol-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the property ID associated with the symbol."
 title: "JsGetPropertyIdFromSymbol Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 190fe4b9-352e-4b10-9d0e-6c6bbd6363e8
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsgetpropertyidtype-function.md
+++ b/developer/hosting/chakra-hosting/jsgetpropertyidtype-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the type of property."
 title: "JsGetPropertyIdType Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 2b6e85ad-c630-4a07-a759-3b344d06faaa
 caps.latest.revision: 3

--- a/developer/hosting/chakra-hosting/jsgetpropertynamefromid-function.md
+++ b/developer/hosting/chakra-hosting/jsgetpropertynamefromid-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the name associated with the property ID."
 title: "JsGetPropertyNameFromId Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetPropertyNameFromId"

--- a/developer/hosting/chakra-hosting/jsgetprototype-function.md
+++ b/developer/hosting/chakra-hosting/jsgetprototype-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Returns the prototype of an object."
 title: "JsGetPrototype Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetPrototype"

--- a/developer/hosting/chakra-hosting/jsgetruntime-function.md
+++ b/developer/hosting/chakra-hosting/jsgetruntime-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the runtime that the context belongs to."
 title: "JsGetRuntime Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetRuntime"

--- a/developer/hosting/chakra-hosting/jsgetruntimememorylimit-function.md
+++ b/developer/hosting/chakra-hosting/jsgetruntimememorylimit-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the current memory limit for a runtime."
 title: "JsGetRuntimeMemoryLimit Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetRuntimeMemoryLimit"

--- a/developer/hosting/chakra-hosting/jsgetruntimememoryusage-function.md
+++ b/developer/hosting/chakra-hosting/jsgetruntimememoryusage-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the current memory usage for a runtime."
 title: "JsGetRuntimeMemoryUsage Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetRuntimeMemoryUsage"

--- a/developer/hosting/chakra-hosting/jsgetstringlength-function.md
+++ b/developer/hosting/chakra-hosting/jsgetstringlength-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the length of a string value."
 title: "JsGetStringLength Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetStringLength"

--- a/developer/hosting/chakra-hosting/jsgetsymbolfrompropertyid-function.md
+++ b/developer/hosting/chakra-hosting/jsgetsymbolfrompropertyid-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the symbol associated with the property ID."
 title: "JsGetSymbolFromPropertyId Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 0e822cb4-ba9e-44df-bf3a-fae97c354daa
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsgettruevalue-function.md
+++ b/developer/hosting/chakra-hosting/jsgettruevalue-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the value of `true` in the current script context."
 title: "JsGetTrueValue Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetTrueValue"

--- a/developer/hosting/chakra-hosting/jsgettypedarrayinfo-function.md
+++ b/developer/hosting/chakra-hosting/jsgettypedarrayinfo-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Obtains frequently used properties of a typed array."
 title: "JsGetTypedArrayInfo Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 992bc4e9-3d06-4ad2-8b6b-88a437360f81
 caps.latest.revision: 3

--- a/developer/hosting/chakra-hosting/jsgettypedarraystorage-function.md
+++ b/developer/hosting/chakra-hosting/jsgettypedarraystorage-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Obtains the underlying memory storage used by a typed array."
 title: "JsGetTypedArrayStorage Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 52e4ac5f-cc71-456d-95de-a48f7327503d
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsgetundefinedvalue-function.md
+++ b/developer/hosting/chakra-hosting/jsgetundefinedvalue-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the value of `undefined` in the current script context."
 title: "JsGetUndefinedValue Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetUndefinedValue"

--- a/developer/hosting/chakra-hosting/jsgetvaluetype-function.md
+++ b/developer/hosting/chakra-hosting/jsgetvaluetype-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Gets the JavaScript type of a JsValueRef."
 title: "JsGetValueType Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsGetValueType"

--- a/developer/hosting/chakra-hosting/jshasexception-function.md
+++ b/developer/hosting/chakra-hosting/jshasexception-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Determines whether the runtime of the current context is in an exception state."
 title: "JsHasException Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsHasException"

--- a/developer/hosting/chakra-hosting/jshasexternaldata-function.md
+++ b/developer/hosting/chakra-hosting/jshasexternaldata-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Determines whether an object is an external object."
 title: "JsHasExternalData Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsHasExternalData"

--- a/developer/hosting/chakra-hosting/jshasindexedpropertiesexternaldata-function.md
+++ b/developer/hosting/chakra-hosting/jshasindexedpropertiesexternaldata-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Determines whether an object has its indexed properties in external data."
 title: "JsHasIndexedPropertiesExternalData Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: c676db20-3ef1-4f84-8b26-3e06fe0ab2bf
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jshasindexedproperty-function.md
+++ b/developer/hosting/chakra-hosting/jshasindexedproperty-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Tests whether an object has a value at the specified index."
 title: "JsHasIndexedProperty Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsHasIndexedProperty"

--- a/developer/hosting/chakra-hosting/jshasproperty-function.md
+++ b/developer/hosting/chakra-hosting/jshasproperty-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Determines whether an object has a property."
 title: "JsHasProperty Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsHasProperty"

--- a/developer/hosting/chakra-hosting/jsidle-function.md
+++ b/developer/hosting/chakra-hosting/jsidle-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Tells the runtime to do any idle processing it need to do."
 title: "JsIdle Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsIdle"

--- a/developer/hosting/chakra-hosting/jsinspectabletoobject-function.md
+++ b/developer/hosting/chakra-hosting/jsinspectabletoobject-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a JavaScript value that is a projection of the passed in `IInspectable` pointer."
 title: "JsInspectableToObject Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: dd0ad567-2ba8-4a63-bee4-2c6ff5ce9fa9
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsinstanceof-function.md
+++ b/developer/hosting/chakra-hosting/jsinstanceof-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Performs JavaScript `instanceof` operator test."
 title: "JsInstanceOf Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 94399a62-b996-4fd2-82ce-1c26e7a4da08
 caps.latest.revision: 6

--- a/developer/hosting/chakra-hosting/jsinttonumber-function.md
+++ b/developer/hosting/chakra-hosting/jsinttonumber-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a number value from an `int` value."
 title: "JsIntToNumber Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 1393c4ac-7189-4e9c-8e54-b0e041c22112
 caps.latest.revision: 4

--- a/developer/hosting/chakra-hosting/jsisenumeratingheap-function.md
+++ b/developer/hosting/chakra-hosting/jsisenumeratingheap-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Returns a value that indicates whether the heap of the current context is being enumerated."
 title: "JsIsEnumeratingHeap Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsIsEnumeratingHeap"

--- a/developer/hosting/chakra-hosting/jsisruntimeexecutiondisabled-function.md
+++ b/developer/hosting/chakra-hosting/jsisruntimeexecutiondisabled-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Returns a value that indicates whether script execution is disabled in the runtime."
 title: "JsIsRuntimeExecutionDisabled Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsIsRuntimeExecutionDisabled"

--- a/developer/hosting/chakra-hosting/jsmemoryallocationcallback-typedef.md
+++ b/developer/hosting/chakra-hosting/jsmemoryallocationcallback-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "User implemented callback routine for memory allocation events."
 title: "JsMemoryAllocationCallback Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 511babc7-3caa-4ee5-82a2-943bbd34db8d
 caps.latest.revision: 7

--- a/developer/hosting/chakra-hosting/jsmemoryeventtype-enumeration.md
+++ b/developer/hosting/chakra-hosting/jsmemoryeventtype-enumeration.md
@@ -1,7 +1,7 @@
 ---
 description: "Allocation callback event type."
 title: "JsMemoryEventType Enumeration | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsMemoryEventType"

--- a/developer/hosting/chakra-hosting/jsnativefunction-typedef.md
+++ b/developer/hosting/chakra-hosting/jsnativefunction-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A function callback."
 title: "JsNativeFunction Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 56ef6cdf-4ca9-4f7c-b953-e661addb1a8e
 caps.latest.revision: 5

--- a/developer/hosting/chakra-hosting/jsnumbertodouble-function.md
+++ b/developer/hosting/chakra-hosting/jsnumbertodouble-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Retrieves the `double` value of a number value."
 title: "JsNumberToDouble Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsNumberToDouble"

--- a/developer/hosting/chakra-hosting/jsnumbertoint-function.md
+++ b/developer/hosting/chakra-hosting/jsnumbertoint-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Retrieves the `int` value of a number value."
 title: "JsNumberToInt Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 8b9256d6-76ac-4c74-a97c-fbb16c13f5f5
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsobjectbeforecollectcallback-typedef.md
+++ b/developer/hosting/chakra-hosting/jsobjectbeforecollectcallback-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A callback called before collecting an object."
 title: "JsObjectBeforeCollectCallback Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: f21a064a-579f-44cb-9d21-76b62e8c18f5
 caps.latest.revision: 3

--- a/developer/hosting/chakra-hosting/jsobjecttoinspectable-function.md
+++ b/developer/hosting/chakra-hosting/jsobjecttoinspectable-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Unwraps a JavaScript object to an `IInspectable` pointer."
 title: "JsObjectToInspectable Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 1d15b0b8-516f-4fc6-95aa-2ddd65f8ab75
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsparsescript-function.md
+++ b/developer/hosting/chakra-hosting/jsparsescript-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Parses a script and returns a function representing the script."
 title: "JsParseScript Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsParseScript"

--- a/developer/hosting/chakra-hosting/jsparseserializedscript-function.md
+++ b/developer/hosting/chakra-hosting/jsparseserializedscript-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Parses a serialized script and returns a function representing the script."
 title: "JsParseSerializedScript Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsParseSerializedScript"

--- a/developer/hosting/chakra-hosting/jsparseserializedscriptwithcallback-function.md
+++ b/developer/hosting/chakra-hosting/jsparseserializedscriptwithcallback-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Parses a serialized script and returns a function representing the script. Provides the ability to lazy load the script source only if/when it is needed."
 title: "JsParseSerializedScriptWithCallback Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 0a93ecfb-4b82-4a85-b24c-6816db2332ea
 caps.latest.revision: 5

--- a/developer/hosting/chakra-hosting/jspointertostring-function.md
+++ b/developer/hosting/chakra-hosting/jspointertostring-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a string value from a string pointer."
 title: "JsPointerToString Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsPointerToString"

--- a/developer/hosting/chakra-hosting/jspreventextension-function.md
+++ b/developer/hosting/chakra-hosting/jspreventextension-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Makes an object non-extensible."
 title: "JsPreventExtension Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsPreventExtension"

--- a/developer/hosting/chakra-hosting/jsprojectioncallback-typedef.md
+++ b/developer/hosting/chakra-hosting/jsprojectioncallback-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "The JsRT callback which should be called with the context passed to `JsProjectionEnqueueCallback` on the correct thread."
 title: "JsProjectionCallback Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 32f22d37-e57e-4196-b6cd-a3fc75bd0632
 caps.latest.revision: 3

--- a/developer/hosting/chakra-hosting/jsprojectioncallbackcontext-typedef.md
+++ b/developer/hosting/chakra-hosting/jsprojectioncallbackcontext-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "The context passed into application callback, JsProjectionEnqueueCallback, from JsRT and then passed back to JsRT in the provided callback, `JsProjectionCallback`, by the application on the correct thread."
 title: "JsProjectionCallbackContext Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 50c705c5-664f-4a1a-92f6-4882fc718ab1
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsprojectionenqueuecallback-typedef.md
+++ b/developer/hosting/chakra-hosting/jsprojectionenqueuecallback-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "The application callback which is called by JsRT when a projection API is completed on a different thread than the original."
 title: "JsProjectionEnqueueCallback Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 19c1cefb-a7be-4196-b780-9fe6adf35ba5
 caps.latest.revision: 4

--- a/developer/hosting/chakra-hosting/jsprojectwinrtnamespace-function.md
+++ b/developer/hosting/chakra-hosting/jsprojectwinrtnamespace-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Project a WinRT namespace."
 title: "JsProjectWinRTNamespace Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 8a23c154-df4b-4ce3-9fef-f41f90acdb87
 caps.latest.revision: 5

--- a/developer/hosting/chakra-hosting/jspromisecontinuationcallback-typedef.md
+++ b/developer/hosting/chakra-hosting/jspromisecontinuationcallback-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A promise continuation callback."
 title: "JsPromiseContinuationCallback Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 51a3fd02-9668-4cf7-bb0b-e1fd03b2528f
 caps.latest.revision: 3

--- a/developer/hosting/chakra-hosting/jspropertyidref-typedef.md
+++ b/developer/hosting/chakra-hosting/jspropertyidref-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A property identifier. "
 title: "JsPropertyIdRef Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 39976437-4e02-4f68-b473-94de209a73f1
 caps.latest.revision: 6

--- a/developer/hosting/chakra-hosting/jspropertyidtype-enumeration.md
+++ b/developer/hosting/chakra-hosting/jspropertyidtype-enumeration.md
@@ -1,7 +1,7 @@
 ---
 description: JsPropertyIdType Enumeration Type enumeration of a JavaScript property.
 title: JsPropertyIdType enumeration
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 1b8293ca-a040-402d-8ea5-4299390adcd0
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsref-typedef.md
+++ b/developer/hosting/chakra-hosting/jsref-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A reference to an object owned by the Chakra garbage collector."
 title: "JsRef Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 6aafc39f-6b9c-457f-8bf0-48831bffe9b8
 caps.latest.revision: 6

--- a/developer/hosting/chakra-hosting/jsrelease-function.md
+++ b/developer/hosting/chakra-hosting/jsrelease-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Releases a reference to a garbage collected object."
 title: "JsRelease Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsRelease"

--- a/developer/hosting/chakra-hosting/jsrunscript-function.md
+++ b/developer/hosting/chakra-hosting/jsrunscript-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Executes a script."
 title: "JsRunScript Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsRunScript"

--- a/developer/hosting/chakra-hosting/jsrunserializedscript-function.md
+++ b/developer/hosting/chakra-hosting/jsrunserializedscript-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Runs a serialized script."
 title: "JsRunSerializedScript Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsRunSerializedScript"

--- a/developer/hosting/chakra-hosting/jsrunserializedscriptwithcallback-function.md
+++ b/developer/hosting/chakra-hosting/jsrunserializedscriptwithcallback-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Runs a serialized script. Provides the ability to lazy load the script source only if/when it is needed."
 title: "JsRunSerializedScriptWithCallback Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 0608d778-f65b-4dc5-a745-364aac57ef59
 caps.latest.revision: 4

--- a/developer/hosting/chakra-hosting/jsruntimeattributes-enumeration.md
+++ b/developer/hosting/chakra-hosting/jsruntimeattributes-enumeration.md
@@ -1,7 +1,7 @@
 ---
 description: "Attributes of a runtime. "
 title: "JsRuntimeAttributes Enumeration | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsRuntimeAttributes"

--- a/developer/hosting/chakra-hosting/jsruntimehandle-typedef.md
+++ b/developer/hosting/chakra-hosting/jsruntimehandle-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A handle to a Chakra runtime."
 title: "JsRuntimeHandle Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 69e59bfd-9b0e-4710-9aa8-fbd6844171bc
 caps.latest.revision: 6

--- a/developer/hosting/chakra-hosting/jsruntimeversion-enumeration.md
+++ b/developer/hosting/chakra-hosting/jsruntimeversion-enumeration.md
@@ -1,7 +1,7 @@
 ---
 description: "Version of the runtime."
 title: "JsRuntimeVersion Enumeration | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsRuntimeVersion"

--- a/developer/hosting/chakra-hosting/jsserializedscriptloadsourcecallback-typedef.md
+++ b/developer/hosting/chakra-hosting/jsserializedscriptloadsourcecallback-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "Called by the runtime to load the source code of the serialized script. The caller must keep the script buffer valid until the `JsSerializedScriptUnloadCallback`."
 title: "JsSerializedScriptLoadSourceCallback Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 9406c488-76ac-49e5-b305-39751f3412ea
 caps.latest.revision: 3

--- a/developer/hosting/chakra-hosting/jsserializedscriptunloadcallback-typedef.md
+++ b/developer/hosting/chakra-hosting/jsserializedscriptunloadcallback-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "Called by the runtime when it is finished with all resources related to the script execution. The caller should free the source if loaded, the byte code, and the context at this time."
 title: "JsSerializedScriptUnloadCallback typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 8d18c392-cca0-411e-9f2b-0d788b16161a
 caps.latest.revision: 3

--- a/developer/hosting/chakra-hosting/jsserializescript-function.md
+++ b/developer/hosting/chakra-hosting/jsserializescript-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Serializes a parsed script to a buffer than can be reused."
 title: "JsSerializeScript Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsSerializeScript"

--- a/developer/hosting/chakra-hosting/jssetcontextdata-function.md
+++ b/developer/hosting/chakra-hosting/jssetcontextdata-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets the internal data of JsrtContext."
 title: "JsSetContextData Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: be90aa6a-b001-4a6f-90c5-c2135e913be0
 caps.latest.revision: 4

--- a/developer/hosting/chakra-hosting/jssetcurrentcontext-function.md
+++ b/developer/hosting/chakra-hosting/jssetcurrentcontext-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets the current script context on the thread."
 title: "JsSetCurrentContext Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsSetCurrentContext"

--- a/developer/hosting/chakra-hosting/jssetexception-function.md
+++ b/developer/hosting/chakra-hosting/jssetexception-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets the runtime of the current context to an exception state."
 title: "JsSetException Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsSetException"

--- a/developer/hosting/chakra-hosting/jssetexternaldata-function.md
+++ b/developer/hosting/chakra-hosting/jssetexternaldata-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets the external data on an external object."
 title: "JsSetExternalData Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsSetExternalData"

--- a/developer/hosting/chakra-hosting/jssetindexedpropertiestoexternaldata-function.md
+++ b/developer/hosting/chakra-hosting/jssetindexedpropertiestoexternaldata-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets an object's indexed properties to external data. The external data will be used as back store for the object's indexed properties and accessed like a typed array."
 title: "JsSetIndexedPropertiesToExternalData Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: cee2d86d-ed42-4acb-86ef-95a67e63d0d6
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jssetindexedproperty-function.md
+++ b/developer/hosting/chakra-hosting/jssetindexedproperty-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Set the value at the specified index of an object."
 title: "JsSetIndexedProperty Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsSetIndexedProperty"

--- a/developer/hosting/chakra-hosting/jssetobjectbeforecollectcallback-function.md
+++ b/developer/hosting/chakra-hosting/jssetobjectbeforecollectcallback-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets a callback function that is called by the runtime before garbage collection of an object."
 title: "JsSetObjectBeforeCollectCallback Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: ea2cbd94-d8b0-4fa9-a4a1-c75a4e338eaf
 caps.latest.revision: 3

--- a/developer/hosting/chakra-hosting/jssetprojectionenqueuecallback-function.md
+++ b/developer/hosting/chakra-hosting/jssetprojectionenqueuecallback-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets the callback to be used in order to invoke a projection completion back to the callers required thread."
 title: "JsSetProjectionEnqueueCallback Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: c751ccef-20d2-4d41-9568-1c54adf47cdf
 caps.latest.revision: 4

--- a/developer/hosting/chakra-hosting/jssetpromisecontinuationcallback-function.md
+++ b/developer/hosting/chakra-hosting/jssetpromisecontinuationcallback-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets a promise continuation callback function that is called by the context when a task needs to be queued for future execution."
 title: "JsSetPromiseContinuationCallback Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 6ef0faf4-1500-4bd9-aeca-c208492af8ea
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jssetproperty-function.md
+++ b/developer/hosting/chakra-hosting/jssetproperty-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Puts an object's property."
 title: "JsSetProperty Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsSetProperty"

--- a/developer/hosting/chakra-hosting/jssetprototype-function.md
+++ b/developer/hosting/chakra-hosting/jssetprototype-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets the prototype of an object."
 title: "JsSetPrototype Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 88e1e421-4ae5-4e3b-b377-19256cc80e9f
 caps.latest.revision: 4

--- a/developer/hosting/chakra-hosting/jssetruntimebeforecollectcallback-function.md
+++ b/developer/hosting/chakra-hosting/jssetruntimebeforecollectcallback-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets a callback function that is called by the runtime before garbage collection. "
 title: "JsSetRuntimeBeforeCollectCallback Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsSetRuntimeBeforeCollectCallback"

--- a/developer/hosting/chakra-hosting/jssetruntimememoryallocationcallback-function.md
+++ b/developer/hosting/chakra-hosting/jssetruntimememoryallocationcallback-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets a memory allocation callback for specified runtime."
 title: "JsSetRuntimeMemoryAllocationCallback Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsSetRuntimeMemoryAllocationCallback"

--- a/developer/hosting/chakra-hosting/jssetruntimememorylimit-function.md
+++ b/developer/hosting/chakra-hosting/jssetruntimememorylimit-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Sets the current memory limit for a runtime."
 title: "JsSetRuntimeMemoryLimit Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsSetRuntimeMemoryLimit"

--- a/developer/hosting/chakra-hosting/jssourcecontext-typedef.md
+++ b/developer/hosting/chakra-hosting/jssourcecontext-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A cookie that identifies a script for debugging purposes."
 title: "JsSourceContext Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 0ee67e5d-a66b-4d4f-ab30-4711ef25c091
 caps.latest.revision: 5

--- a/developer/hosting/chakra-hosting/jsstartdebugging-function.md
+++ b/developer/hosting/chakra-hosting/jsstartdebugging-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Starts debugging in the current context."
 title: "JsStartDebugging Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsStartDebugging"

--- a/developer/hosting/chakra-hosting/jsstartprofiling-function.md
+++ b/developer/hosting/chakra-hosting/jsstartprofiling-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Starts profiling in the current context."
 title: "JsStartProfiling Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsStartProfiling"

--- a/developer/hosting/chakra-hosting/jsstopprofiling-function.md
+++ b/developer/hosting/chakra-hosting/jsstopprofiling-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Stops profiling in the current context."
 title: "JsStopProfiling Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsStopProfiling"

--- a/developer/hosting/chakra-hosting/jsstrictequals-function.md
+++ b/developer/hosting/chakra-hosting/jsstrictequals-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Compare two JavaScript values for strict equality."
 title: "JsStrictEquals Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsStrictEquals"

--- a/developer/hosting/chakra-hosting/jsstringtopointer-function.md
+++ b/developer/hosting/chakra-hosting/jsstringtopointer-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Retrieves the string pointer of a string value."
 title: "JsStringToPointer Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsStringToPointer"

--- a/developer/hosting/chakra-hosting/jsthreadservicecallback-typedef.md
+++ b/developer/hosting/chakra-hosting/jsthreadservicecallback-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A thread service callback."
 title: "JsThreadServiceCallback Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: dbe67be5-418a-4f66-8b68-b38078a6d140
 caps.latest.revision: 6

--- a/developer/hosting/chakra-hosting/jstypedarraytype-enumeration.md
+++ b/developer/hosting/chakra-hosting/jstypedarraytype-enumeration.md
@@ -1,7 +1,7 @@
 ---
 description: "The type of a typed JavaScript array."
 title: "JsTypedArrayType Enumeration | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 67f3e51c-acbb-4fff-a414-0868a0dd5051
 caps.latest.revision: 2

--- a/developer/hosting/chakra-hosting/jsvalueref-typedef.md
+++ b/developer/hosting/chakra-hosting/jsvalueref-typedef.md
@@ -1,7 +1,7 @@
 ---
 description: "A reference to a JavaScript value."
 title: "JsValueRef Typedef | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 ms.assetid: 78a64aad-70b3-49b0-b961-6064eae19129
 caps.latest.revision: 6

--- a/developer/hosting/chakra-hosting/jsvaluetovariant-function.md
+++ b/developer/hosting/chakra-hosting/jsvaluetovariant-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Initializes the passed in `VARIANT` as a projection of a JavaScript value."
 title: "JsValueToVariant Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsValueToVariant"

--- a/developer/hosting/chakra-hosting/jsvaluetype-enumeration.md
+++ b/developer/hosting/chakra-hosting/jsvaluetype-enumeration.md
@@ -1,7 +1,7 @@
 ---
 description: "The JavaScript type of a JsValueRef."
 title: "JsValueType Enumeration | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsValueType"

--- a/developer/hosting/chakra-hosting/jsvarianttovalue-function.md
+++ b/developer/hosting/chakra-hosting/jsvarianttovalue-function.md
@@ -1,7 +1,7 @@
 ---
 description: "Creates a JavaScript value that is a projection of the passed in `VARIANT`."
 title: "JsVariantToValue Function | Microsoft Docs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "reference"
 f1_keywords: 
   - "jsrt/JsVariantToValue"

--- a/developer/hosting/chakra-hosting/reference-javascript-runtime.md
+++ b/developer/hosting/chakra-hosting/reference-javascript-runtime.md
@@ -1,7 +1,7 @@
 ---
 description: "JavaScript Runtime (JsRT) APIs enable you to add scripting capabilities to desktop and server-side applications running on Windows."
 title: "Reference (JavaScript Runtime)"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "article"
 ms.assetid: 0bfe50da-fd79-4e00-9458-bc667769b415
 caps.latest.revision: 9

--- a/developer/hosting/chakra-hosting/targeting-edge-vs-legacy-engines-in-jsrt-apis.md
+++ b/developer/hosting/chakra-hosting/targeting-edge-vs-legacy-engines-in-jsrt-apis.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn how to target the different Windows 10 JavaScript engines. "
 title: "Targeting Microsoft Edge vs. Legacy engines in JsRT APIs"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "article"
 ms.assetid: cbc7df6c-0bc9-48f5-b9ad-b9ed31c42f92
 caps.latest.revision: 7

--- a/developer/hosting/includes/deprecation-note.md
+++ b/developer/hosting/includes/deprecation-note.md
@@ -1,7 +1,7 @@
 ---
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: include
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/javascript-runtime-hosting.md
+++ b/developer/hosting/javascript-runtime-hosting.md
@@ -1,7 +1,7 @@
 ---
 description: The JavaScript Runtime (JsRT) APIs provide a way for desktop, Windows Store, and server-side applications running on the Windows operating system to add scripting capabilities to an app by using the standards-based Chakra JavaScript engine that is also utilized by Microsoft Edge and Internet Explorer.
 title: "JavaScript Runtime Hosting"
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: "article"
 ms.assetid: d6615079-2df7-420f-a126-077e7d42486c
 caps.latest.revision: 6

--- a/developer/hosting/webview/DeferredPermissionRequest.md
+++ b/developer/hosting/webview/DeferredPermissionRequest.md
@@ -4,7 +4,7 @@ title: DeferredPermissionRequest object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/FocusNavigationEvent.md
+++ b/developer/hosting/webview/FocusNavigationEvent.md
@@ -4,7 +4,7 @@ title: FocusNavigationEvent object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/LongRunningScriptDetectedEvent.md
+++ b/developer/hosting/webview/LongRunningScriptDetectedEvent.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/hosting/webview/MSWebViewAsyncOperation.md
+++ b/developer/hosting/webview/MSWebViewAsyncOperation.md
@@ -4,7 +4,7 @@ title: MSWebViewAsyncOperation object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/MSWebViewProcess.md
+++ b/developer/hosting/webview/MSWebViewProcess.md
@@ -4,7 +4,7 @@ title: MSWebViewProcess object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/MSWebViewSettings.md
+++ b/developer/hosting/webview/MSWebViewSettings.md
@@ -4,7 +4,7 @@ title: MSWebViewSettings object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/NavigationCompletedEvent.md
+++ b/developer/hosting/webview/NavigationCompletedEvent.md
@@ -4,7 +4,7 @@ title: NavigationCompletedEvent object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/NavigationEvent.md
+++ b/developer/hosting/webview/NavigationEvent.md
@@ -4,7 +4,7 @@ title: NavigationEvent object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/NavigationEventWithReferrer.md
+++ b/developer/hosting/webview/NavigationEventWithReferrer.md
@@ -4,7 +4,7 @@ title: NavigationEventWithReferrer object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/PermissionRequest.md
+++ b/developer/hosting/webview/PermissionRequest.md
@@ -4,7 +4,7 @@ title: PermissionRequest object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/PermissionRequestedEvent.md
+++ b/developer/hosting/webview/PermissionRequestedEvent.md
@@ -4,7 +4,7 @@ title: PermissionRequestedEvent object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/ScriptNotifyEvent.md
+++ b/developer/hosting/webview/ScriptNotifyEvent.md
@@ -4,7 +4,7 @@ title: ScriptNotifyEvent object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/UnviewableContentIdentifiedEvent.md
+++ b/developer/hosting/webview/UnviewableContentIdentifiedEvent.md
@@ -4,7 +4,7 @@ title: UnviewableContentIdentifiedEvent object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/WebResourceRequestedEvent.md
+++ b/developer/hosting/webview/WebResourceRequestedEvent.md
@@ -4,7 +4,7 @@ title: WebResourceRequestedEvent object
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: webview, windows 10 apps, uwp, edge
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/hosting/webview/index.md
+++ b/developer/hosting/webview/index.md
@@ -4,7 +4,7 @@ title: Microsoft Edge WebView for Windows 10 apps
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: webview
 keywords: x-ms-webview, MSHTMLWebViewElement, webview, windows 10 apps, uwp, edge
 ms.date: 12/02/2020

--- a/developer/includes/legacy-edge-note.md
+++ b/developer/includes/legacy-edge-note.md
@@ -1,7 +1,7 @@
 ---
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: include
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/includes/new-devtools-version-note.md
+++ b/developer/includes/new-devtools-version-note.md
@@ -1,7 +1,7 @@
 ---
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.topic: include
 ms.date: 11/19/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/index.md
+++ b/developer/index.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 04/19/2021
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: devtools
 keywords: microsoft edge, web development, f12 tools, devtools
 ---

--- a/developer/performance-analysis/index.md
+++ b/developer/performance-analysis/index.md
@@ -4,7 +4,7 @@ title: Performance analysis
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.assetid: 7a5f9fd0-90a9-43db-b271-178c06da5896
 keywords: edge, web development, html, css, javascript, developer
 ms.date: 12/15/2020

--- a/developer/progressive-web-apps/get-started.md
+++ b/developer/progressive-web-apps/get-started.md
@@ -4,7 +4,7 @@ title: Get started with Progressive Web Apps
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: progressive web apps, PWA, Edge, Windows, PWABuilder, web manifest, service worker, push
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/progressive-web-apps/index.md
+++ b/developer/progressive-web-apps/index.md
@@ -4,7 +4,7 @@ title: Progressive Web Apps (EdgeHTML) on Windows
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: pwa
 keywords: progressive web apps, PWA, Edge, JavaScript, Windows, UWP, Microsoft Store
 ms.date: 04/02/2020

--- a/developer/progressive-web-apps/microsoft-store.md
+++ b/developer/progressive-web-apps/microsoft-store.md
@@ -4,7 +4,7 @@ title: Progressive Web Apps in the Microsoft Store
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: progressive web apps, PWA, Edge, Windows, Microsoft Store, Bing PWA index
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/progressive-web-apps/windows-features.md
+++ b/developer/progressive-web-apps/windows-features.md
@@ -4,7 +4,7 @@ title: Tailor your PWA (EdgeHTML) for Windows
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: progressive web apps, PWA, Edge, Windows, WinRT, UWP, EdgeHTML
 ms.date: 12/02/2020
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/progressive-web-apps/xbox-considerations.md
+++ b/developer/progressive-web-apps/xbox-considerations.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 11/03/2020
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: progressive web apps, PWA, Edge, Windows, UWP, Xbox, Xbox One, TVJS
 ROBOTS: NOINDEX,NOFOLLOW
 ---

--- a/developer/webdriver/index.md
+++ b/developer/webdriver/index.md
@@ -5,7 +5,7 @@ title: WebDriver (EdgeHTML)
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: devtools
 keywords: edge, web development, html, css, javascript, developer, webdriver, selenium, testing
 ms.date: 11/19/2020

--- a/developer/windows-runtime/considerations-when-using-the-windows-runtime-api.md
+++ b/developer/windows-runtime/considerations-when-using-the-windows-runtime-api.md
@@ -3,7 +3,7 @@ description: Considerations when using the Windows Runtime API
 title: "Considerations when Using the Windows Runtime API"
 ms.custom: ""
 ms.date: 11/03/2020
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: "windows-integration"
 ms.topic: "article"
 helpviewer_keywords: 

--- a/developer/windows-runtime/error-codes-for-windows-runtime-apps-using-javascript.md
+++ b/developer/windows-runtime/error-codes-for-windows-runtime-apps-using-javascript.md
@@ -3,7 +3,7 @@ description: Error codes for Windows Runtime apps using JavaScript
 title: "Error codes for Windows Runtime apps using JavaScript"
 ms.custom: ""
 ms.date: 11/03/2020
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: "windows-integration"
 ms.topic: "article"
 f1_keywords:

--- a/developer/windows-runtime/handling-windows-runtime-events-in-javascript.md
+++ b/developer/windows-runtime/handling-windows-runtime-events-in-javascript.md
@@ -3,7 +3,7 @@ description: Handling Windows Runtime Events in JavaScript
 title: "Handling Windows Runtime Events in JavaScript"
 ms.custom: ""
 ms.date: 11/03/2020
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: "windows-integration"
 ms.topic: "article"
 helpviewer_keywords: 

--- a/developer/windows-runtime/index.md
+++ b/developer/windows-runtime/index.md
@@ -4,7 +4,7 @@ title: Windows Runtime (WinRT) for JavaScript
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: windows-integration
 keywords: Windows Runtime, WinRT, PWA, JavaScript
 ms.date: 12/02/2020

--- a/developer/windows-runtime/javascript-representation-of-windows-runtime-types.md
+++ b/developer/windows-runtime/javascript-representation-of-windows-runtime-types.md
@@ -3,7 +3,7 @@ description: JavaScript Representation of Windows Runtime Types
 title: "JavaScript Representation of Windows Runtime Types"
 ms.custom: ""
 ms.date: 10/30/2020
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: "windows-integration"
 ms.topic: "article"
 helpviewer_keywords: 

--- a/developer/windows-runtime/reference/msapp.md
+++ b/developer/windows-runtime/reference/msapp.md
@@ -4,7 +4,7 @@ description: Provides helper functions that enable you to create Blob and MSStre
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: reference
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 keywords: MSapp, PWA, file upload, Blog, MSStream, windows 10 apps, uwp, edge
 ms.date: 03/16/2021
 ROBOTS: NOINDEX,NOFOLLOW

--- a/developer/windows-runtime/special-error-properties-from-asynchronous-windows-runtime-methods.md
+++ b/developer/windows-runtime/special-error-properties-from-asynchronous-windows-runtime-methods.md
@@ -3,7 +3,7 @@ description: Special Error Properties from Asynchronous Windows Runtime Methods
 title: "Special Error Properties from Asynchronous Windows Runtime Methods"
 ms.custom: ""
 ms.date: 11/03/2020
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: "windows-integration"
 ms.topic: "article"
 ms.assetid: 45155584-06d8-4e7f-93a6-8564a93f643d

--- a/developer/windows-runtime/using-the-windows-runtime-in-javascript.md
+++ b/developer/windows-runtime/using-the-windows-runtime-in-javascript.md
@@ -3,7 +3,7 @@ description: Using the Windows Runtime in JavaScript
 title: "Using the Windows Runtime in JavaScript"
 ms.custom: ""
 ms.date: 11/03/2020
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: "windows-integration"
 ms.topic: "article"
 helpviewer_keywords: 

--- a/developer/windows-runtime/using-windows-runtime-asynchronous-methods.md
+++ b/developer/windows-runtime/using-windows-runtime-asynchronous-methods.md
@@ -3,7 +3,7 @@ description: Using Windows Runtime Asynchronous Methods
 title: "Using Windows Runtime Asynchronous Methods"
 ms.custom: ""
 ms.date: 11/03/2020
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: "windows-integration"
 ms.topic: "article"
 helpviewer_keywords: 

--- a/developer/windows-runtime/windows-runtime-datetime-and-timespan-representations.md
+++ b/developer/windows-runtime/windows-runtime-datetime-and-timespan-representations.md
@@ -3,7 +3,7 @@ description: Windows Runtime DateTime and TimeSpan Representations
 title: "Windows Runtime DateTime and TimeSpan Representations"
 ms.custom: ""
 ms.date: 11/03/2020
-ms.prod: microsoft-edge
+ms.service: microsoft-edge
 ms.technology: "windows-integration"
 ms.topic: "article"
 helpviewer_keywords: 


### PR DESCRIPTION
A Pull Request has been made from the Learn Platform's Metadata Management System. Please review and merge this Pull Request within 5 days. If you have any questions or concerns about the purpose of these metadata updates, please contact [docs-allowlist-mgmt@microsoft.com](mailto:docs-allowlist-mgmt@microsoft.com). If you are not the correct contact for this content and repository, please notify [Metadata-Management@microsoft.com](mailto:Metadata-Management@microsoft.com).

If this Pull Request is not merged within 14 days, it will be automatically merged by our system to ensure the timeliness of the metadata update. This includes bypassing the Repository's Branch Policy, including if Review Required is enabled. Please notify [Metadata-Management@microsoft.com](mailto:Metadata-Management@microsoft.com) if you have questions or concerns or would like Pull Requests for metadata updates to merge automatically in future.



Summary
In Germanium, the ms.prod and ms.technology metadata attributes will be retired from the Learn platform and values will be consolidated into ms.service and ms.subservice for reporting on content by product.

C+E Skilling Content Architecture manages internal, business-facing taxonomies that enable reporting on key metrics for content published on Microsoft Learn. Authors manually apply values from these taxonomies to populate metadata attributes.
Two of these taxonomies are [ms.prod/ms.technology](https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies?branch=main#msprod) and [ms.service/ms.subservice](https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies?branch=main#msservice). "ms.prod" and "ms.service" were distinctions carried over from legacy systems that predated the Learn platform, intended to differentiate on-prem products from cloud services.
We plan to rename the attributes from ms.service and ms.subservice in a future semester.
Why are we making this change?

For the business: Accuracy of reporting metadata directly impacts the accuracy of content analytics, so it's important that related taxonomies reflect the current state of the business. Most product taxonomies within Microsoft no longer distinguish between "on-prem" and "cloud service."
For content authors: We eliminate the need to choose between two similar attributes when applying reporting metadata to content or filtering reports.
For engineers, data scientists, and taxonomists: Simplifying and reducing underlying metadata attributes reduces the cost and complexity required to extend metadata capabilities on the platform.
How does this affect me?

Once changes to reporting metadata are merged, dashboards and reports maintained by Skilling Insights & Intelligence will reflect new values. If you've been using ms.prod/ms.technology filters, you'll switch to ms.service/ms.subservice filters in those dashboards and reports.
If you have custom dashboards or Kusto queries, you might need to update those as well.
Frequently Asked Questions
Why does this Pull Request appear to be made by the Repository Owner? We open Pull Requests two different ways.

For Git Repos with a permissioned Service Account, we open the PR from our Document Build Service Account.
For Git Repos that we either do not have Service Account permission for or the repo is in Azure Repos (ADO) we open the Pull Requests in an automated way with the PR creator as the Repo owner.
How can I revert a Pull Request that has been merged and created an unexpected issue? Whether a PR has been merged manually or automatically, you can revert it if an issue arises. See [Reverting a pull request - GitHub Docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/reverting-a-pull-request).